### PR TITLE
Fix showZoomControl

### DIFF
--- a/src/Fields/OSMMap.php
+++ b/src/Fields/OSMMap.php
@@ -144,7 +144,7 @@ class OSMMap extends Field implements MapOptions
      */
     public function showZoomControl(bool $show = true): self
     {
-        $this->mapConfig['controls']['zoomControl'] = $show;
+        $this->controls['zoomControl'] = $show;
         return $this;
     }
 


### PR DESCRIPTION
If you call `showZoomControl` nothing happens as the setting is overwritten, the value needs to be updated in the `controls` array