### PR TITLE
fix upgrade with livewire 3.x (using new field wrapper)

### DIFF
--- a/resources/views/fields/osm-map-picker.blade.php
+++ b/resources/views/fields/osm-map-picker.blade.php
@@ -1,4 +1,6 @@
-<x-forms::field-wrapper
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
     :id="$getId()"
     :label="$getLabel()"
     :label-sr-only="$isLabelHidden()"
@@ -56,4 +58,4 @@
     {{--            </div>--}}
     {{--        </div>--}}
     {{--    </div>--}}
-</x-forms::field-wrapper>
+</x-dynamic-component>


### PR DESCRIPTION
The view was not correctly updated with Filament 3.x, needed the new dynamic component thing that they use to add the field wrapper as a function

Now this should only be for 3.x so I recommend to use a minor/major version release as Filament 2.x users will experience headaches try to figure out why they can't run `composer update`